### PR TITLE
fix: added swagger paths to cmake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -60,6 +60,13 @@ add_definitions(
         -DDATABASE_MIGRATIONS="${CMAKE_CURRENT_SOURCE_DIR}/sql"
 )
 
+set(SWAGGER_ROOT_PATH "/swagger" CACHE STRING "Default root path to the Swagger")
+set(SWAGGER_UI_PATH "/ui" CACHE STRING "Default path suffix to the Swagger UI")
+add_compile_definitions(
+    SWAGGER_ROOT_PATH="${SWAGGER_ROOT_PATH}"
+    SWAGGER_UI_PATH="${SWAGGER_UI_PATH}"
+)
+
 if(CMAKE_SYSTEM_NAME MATCHES Linux)
     find_package(Threads REQUIRED)
     target_link_libraries(crud-lib INTERFACE Threads::Threads ${CMAKE_DL_LIBS})


### PR DESCRIPTION
I had the same problem as https://github.com/oatpp/oatpp-swagger/issues/61.
So I applied the same commit (https://github.com/oatpp/oatpp-swagger/commit/652f95c6fbc31d8bc17f94fd7820fba01399e8ec#diff-1e7de1ae2d059d21e1dd75d5812d5a34b0222cef273b7c3a2af62eb747f9d20aR101-R107) to this example and it worked for me.