### PR TITLE
Adds support for building earlier releases using docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,5 @@
 FROM alpine:latest
+ARG VERSION=""
 
 RUN apk update && apk upgrade
 
@@ -12,7 +13,7 @@ ADD . /service
 
 WORKDIR /service/utility
 
-RUN ./install-oatpp-modules.sh Release
+RUN ./install-oatpp-modules.sh Release $VERSION
 
 WORKDIR /service/build
 

--- a/README.md
+++ b/README.md
@@ -72,6 +72,13 @@ $ docker build -t example-crud .
 $ docker run -p 8000:8000 -t example-crud
 ```
 
+**Note**: If you build an earlier release, you must specify the release version as an
+build argument, as shown below.
+```
+$ docker build -t example-crud --build-arg VERSION=1.3.0-latest .
+$ docker run -p 8000:8000 -t example-crud
+```
+
 ---
 
 ### Endpoints 

--- a/utility/install-oatpp-modules.sh
+++ b/utility/install-oatpp-modules.sh
@@ -1,6 +1,7 @@
 #!/bin/sh
 
 BUILD_TYPE=$1
+VERSION=$2
 
 if [ -z "$BUILD_TYPE" ]; then
     BUILD_TYPE="Debug"
@@ -18,15 +19,22 @@ function install_module () {
 
 BUILD_TYPE=$1
 MODULE_NAME=$2
+VERSION=$3
 NPROC=$(nproc)
 
 if [ -z "$NPROC" ]; then
     NPROC=1
 fi
 
-echo "\n\nINSTALLING MODULE '$MODULE_NAME' ($BUILD_TYPE) using $NPROC threads ...\n\n"
 
-git clone --depth=1 https://github.com/oatpp/$MODULE_NAME
+if [ -z "$3" ]; then
+    echo "\n\nINSTALLING MODULE '$MODULE_NAME' ($BUILD_TYPE) using $NPROC threads ...\n\n"
+    git clone --depth=1 https://github.com/oatpp/$MODULE_NAME
+else
+    echo "\n\nINSTALLING MODULE '$MODULE_NAME $VERSION' ($BUILD_TYPE) using $NPROC threads ...\n\n"
+    git clone --depth=1 https://github.com/oatpp/$MODULE_NAME --branch $VERSION
+fi
+
 
 cd $MODULE_NAME
 mkdir build
@@ -44,9 +52,9 @@ cd ../../
 
 ##########################################################
 
-install_module $BUILD_TYPE oatpp
-install_module $BUILD_TYPE oatpp-swagger
-install_module $BUILD_TYPE oatpp-sqlite
+install_module $BUILD_TYPE oatpp $VERSION
+install_module $BUILD_TYPE oatpp-swagger $VERSION
+install_module $BUILD_TYPE oatpp-sqlite $VERSION
 
 cd ../
 rm -rf tmp


### PR DESCRIPTION
# Description
In response to #36, this PR adds support for building earlier releases of the project using the docker file, and the provided installation script `install-oatpp-modules.sh`. The behaviour on the consumer side, has not changed, meaning that the latest version can still build an run by the following commands:
```
$ docker build -t example-crud .
$ docker run -p 8000:8000 -t example-crud
```
However, if you are to build and run an earlier release of `example-crud`, you can now specify the version number as an build argument, thus preventing the CMake build from failing, due to mismatching version numbers. Thus building version `1.3.0-latest` would require the following commands:
```
$ docker build -t example-crud --build-arg VERSION=1.3.0-latest .
$ docker run -p 8000:8000 -t example-crud
```

# Details
This behaviour was achieved by changing the installation script `install-oatpp-modules.sh` to accept an extra argument, specifying the version number. If such an argument is provided, the flag `--branch` will be specified upon cloning the required dependencies. Furthermore, a new info message has been provided, such that it can be differentiated between cloning the latest release and cloning a specific release.

To improve usability on the consumer side, a build argument was added to the docker file, in order to propagate the version number into the installation script.

The `README.md` has been changed to describe how to build earlier releases of the project.